### PR TITLE
Exclude Carthage folder the same way Pods is

### DIFF
--- a/lib/fus/finder.rb
+++ b/lib/fus/finder.rb
@@ -9,6 +9,7 @@ module Fus
       @swift_paths = Dir
           .glob("#{path}/**/*.swift")
           .select {|path| path.scan(/\/Pods\//).empty? }
+          .select {|path| path.scan(/\/Carthage\//).empty? }
       @obj_c_paths = Dir.glob("#{path}/**/*.m") + Dir.glob("#{path}/**/*.h")
         .select {|path| path.scan(/-Swift.h/).empty? }
       @ib_paths = (Dir.glob("#{path}/**/*.xib") + 


### PR DESCRIPTION
Hi @tsabend, this is a very nice tool, thanks for sharing it.

I run it on my day job Xcode project, which uses Carthage to resolve dependencies, and got a crash.

I think it was due to the fact that we are using a project called [Reachability.swift](https://github.com/ashleymills/Reachability.swift), which Carthage fetches into a folder with the same name, including the `.swift` part. `fus` then tries to read the content of what it thinks it's the filed `Reachability.swift`, but that's actually a folder.

```
Errno::EISDIR: Is a directory @ io_fread - /Users/gio/Developer/iflix/ios/Carthage/Checkouts/Reachability.swift
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:35:in `read'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:35:in `block in swift_classes'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:35:in `each'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:35:in `reduce'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:35:in `swift_classes'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:43:in `unused_classes'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/lib/fus/finder.rb:20:in `unused_classnames'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/bin/fus:14:in `find'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/gems/fus-0.0.2/bin/fus:34:in `<top (required)>'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/bin/fus:23:in `load'
  /Users/gio/Developer/iflix/ios/vendor/bundle/ruby/2.3.0/bin/fus:23:in `<top (required)>'
```

This PR **does not** fix the issue that results in that crash, but just quickly works around it by excluding the Carthage folder, the same way that the Pods one is already excluded.

I think this is an acceptable workaround for the time being, given that it mimics an already existing behaviour.